### PR TITLE
For adding callback to handle renamex

### DIFF
--- a/src/Adaptor/adaptor.c
+++ b/src/Adaptor/adaptor.c
@@ -78,6 +78,12 @@ adaptor_rename (const char *oldpath, const char *newpath)
 }
 
 static int
+adaptor_renamex (const char *oldpath, const char *newpath, unsigned int flags)
+{
+    return _adaptor_get_private_data()->renamex (oldpath, newpath, flags);
+}
+
+static int
 adaptor_link (const char *oldpath, const char *newpath)
 {
     return _adaptor_get_private_data()->link (oldpath, newpath);
@@ -371,6 +377,7 @@ static void initalise_fuse_operations_struct (struct NetFuse_Operations *from, s
     if (from->rmdir)        to->rmdir       = adaptor_rmdir;
     if (from->symlink)      to->symlink     = adaptor_symlink;
     if (from->rename)       to->rename      = adaptor_rename;
+    if (from->renamex)      to->renamex     = adaptor_renamex;
     if (from->link)         to->link        = adaptor_link;
     if (from->chmod)        to->chmod       = adaptor_chmod;
     if (from->chown)        to->chown       = adaptor_chown;

--- a/src/Adaptor/definitions.h
+++ b/src/Adaptor/definitions.h
@@ -54,6 +54,7 @@ typedef int (*RemoveDirectoryCb) (const char* path);
 typedef int (*RemoveFileCb) (const char* path);
 typedef int (*RemovePathExtendedAttributeCb) (const char* path, const char* name);
 typedef int (*RenamePathCb) (const char* oldpath, const char* newpath);
+typedef int (*RenameXPathCb) (const char* oldpath, const char* newpath, unsigned int flags);
 typedef int (*SetPathExtendedAttributeCb) (const char* path, const char* name, unsigned char* value, guint64 size, int flags);
 typedef int (*SynchronizeDirectoryCb) (const char* path, int onlyUserData, void* info);
 typedef int (*SynchronizeHandleCb) (const char* path, int onlyUserData, void* info);
@@ -92,6 +93,7 @@ struct NetFuse_Operations {
 	RemoveDirectoryCb               rmdir;
 	CreateSymbolicLinkCb            symlink;
 	RenamePathCb                    rename;
+	RenameXPathCb                   renamex;
 	CreateHardLinkCb                link;
 	ChangePathPermissionsCb         chmod;
 	ChangePathOwnerCb               chown;

--- a/src/FuseSharp/FuseSharp/FileSystem.cs
+++ b/src/FuseSharp/FuseSharp/FileSystem.cs
@@ -55,6 +55,11 @@ namespace FuseSharp
             return Errno.ENOSYS;
         }
 
+        public virtual Errno OnRenameXPath(string oldpath, string newpath, RenameFlags renameFlags)
+        {
+            return Errno.ENOSYS;
+        }
+
         public virtual Errno OnCreateHardLink(string oldpath, string link)
         {
             return Errno.ENOSYS;
@@ -224,6 +229,14 @@ namespace FuseSharp
             physical = ulong.MaxValue;
             return Errno.ENOSYS;
         }
+    }
 
+    [CLSCompliant(false)]
+    [Flags]
+    public enum RenameFlags: uint
+    {
+        RenameReplace = 0,
+        RenameSwap = 1 << 1,
+        RenameExcl = 1 << 2,
     }
 }

--- a/src/FuseSharp/FuseSharp/FileSystemHandler.cs
+++ b/src/FuseSharp/FuseSharp/FileSystemHandler.cs
@@ -42,6 +42,7 @@ namespace FuseSharp
                 _operations.rmdir = _OnRemoveDirectory;
                 _operations.symlink = _OnCreateSymbolicLink;
                 _operations.rename = _OnRenamePath;
+                _operations.renamex = _OnRenameXPath;
                 _operations.link = _OnCreateHardLink;
                 _operations.chmod = _OnChangePathPermissions;
                 _operations.chown = _OnChangePathOwner;
@@ -242,6 +243,21 @@ namespace FuseSharp
             try
             {
                 errno = _filesystem.OnRenamePath(oldpath, newpath);
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.ToString());
+                errno = Errno.EIO;
+            }
+            return Interop.ConvertErrno(errno);
+        }
+
+        private int _OnRenameXPath(string oldpath, string newpath, uint flags)
+        {
+            Errno errno;
+            try
+            {
+                errno = _filesystem.OnRenameXPath(oldpath, newpath, (RenameFlags)flags);
             }
             catch (Exception e)
             {

--- a/src/FuseSharp/FuseSharp/Operations.cs
+++ b/src/FuseSharp/FuseSharp/Operations.cs
@@ -33,6 +33,13 @@ namespace FuseSharp
             string oldpath,
             [MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
             string newpath);
+    public delegate int RenameXPathCb(
+            [MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+            string oldpath,
+            [MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
+            string newpath,
+            uint flags);
+
     public delegate int CreateHardLinkCb(
             [MarshalAs (UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(FileNameMarshaler))]
             string oldpath,
@@ -147,6 +154,7 @@ namespace FuseSharp
         public RemoveDirectoryCb rmdir;
         public CreateSymbolicLinkCb symlink;
         public RenamePathCb rename;
+        public RenameXPathCb renamex;
         public CreateHardLinkCb link;
         public ChangePathPermissionsCb chmod;
         public ChangePathOwnerCb chown;


### PR DESCRIPTION
During the hackweek, we needed to add this additional callback. It allows more precise control over replace(2) behavior.

To give it a try, we used something similar to this:

```
#include <stdio.h>

int main()
{
	unsigned int flags = RENAME_SWAP;

	if (renamex_np(argv[1], argv[2], flags) < 0) {
		perror(argv[1]);
	}

	return 0;
}
```

Where flags can be:

- Zero (it will **replace** the destination if it exists, as rename(2) would normally do).
- RENAME_EXCL (it will fail if the destination already exists).
- RENAME_SWAP (exchanges source and destination).

See also: https://www.unix.com/man-page/mojave/2/renamex_np/